### PR TITLE
feat: Implement M8 KPI and Reporting Structure

### DIFF
--- a/app/agents/kpi.py
+++ b/app/agents/kpi.py
@@ -1,0 +1,67 @@
+"""
+Agent responsible for calculating and storing KPI snapshots.
+"""
+import logging
+import psycopg
+
+from .base import Agent
+from app.kpi.services import calculate_all_kpis
+
+logger = logging.getLogger(__name__)
+
+class KpiAgent(Agent):
+    """
+    This agent periodically calculates operational KPIs and saves them to the
+    database.
+    """
+
+    def __init__(self, db_connection: psycopg.Connection):
+        """
+        Initializes the KpiAgent.
+
+        Args:
+            db_connection: An active psycopg connection to the database.
+        """
+        self.db_connection = db_connection
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def run(self):
+        """
+        The main entry point for the agent's logic.
+
+        It calculates KPIs and writes them to the `ops_kpi_snapshots` table.
+        """
+        self.logger.info("KpiAgent running...")
+        try:
+            # 1. Calculate KPIs using the service
+            kpi_snapshot = calculate_all_kpis(self.db_connection)
+
+            # 2. Save the snapshot to the database
+            with self.db_connection.cursor() as cursor:
+                insert_query = """
+                    INSERT INTO ops_kpi_snapshots (
+                        ts, order_latency_p50_ms, order_latency_p95_ms,
+                        order_failure_rate, order_retry_rate,
+                        position_gross_exposure_usd, open_positions_count
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (ts) DO NOTHING;
+                """
+                cursor.execute(
+                    insert_query,
+                    (
+                        kpi_snapshot.ts,
+                        kpi_snapshot.order_latency_p50_ms,
+                        kpi_snapshot.order_latency_p95_ms,
+                        kpi_snapshot.order_failure_rate,
+                        kpi_snapshot.order_retry_rate,
+                        kpi_snapshot.position_gross_exposure_usd,
+                        kpi_snapshot.open_positions_count,
+                    ),
+                )
+                self.db_connection.commit()
+                self.logger.info(f"Successfully saved KPI snapshot for ts: {kpi_snapshot.ts}")
+
+        except Exception as e:
+            self.logger.error(f"An error occurred during KPI processing: {e}", exc_info=True)
+            # In a real app, you might want to rollback the transaction
+            self.db_connection.rollback()

--- a/app/agents/report.py
+++ b/app/agents/report.py
@@ -1,0 +1,114 @@
+"""
+Agent responsible for generating and sending performance reports.
+"""
+import logging
+import psycopg
+from datetime import datetime
+
+from .base import Agent
+from app.models import OpsKpiSnapshot
+
+logger = logging.getLogger(__name__)
+
+# In a real application, this would come from a config or user settings in the DB
+DEFAULT_REPORT_CHAT_ID = -1001234567890 # Placeholder Channel ID
+
+class ReportAgent(Agent):
+    """
+    This agent generates a summary report based on the latest KPI snapshot
+    and sends it as a notification.
+    """
+
+    def __init__(self, db_connection: psycopg.Connection):
+        """
+        Initializes the ReportAgent.
+
+        Args:
+            db_connection: An active psycopg connection to the database.
+        """
+        self.db_connection = db_connection
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def run(self):
+        """
+        The main entry point for the agent's logic.
+
+        It fetches the latest KPI data, formats a report, and enqueues it for
+        sending via the notification worker.
+        """
+        self.logger.info("ReportAgent running...")
+        try:
+            snapshot = self._fetch_latest_kpi_snapshot()
+
+            if not snapshot:
+                self.logger.info("No KPI snapshot found. Skipping report generation.")
+                return
+
+            report_message = self._format_report(snapshot)
+            self._enqueue_report(report_message)
+
+        except Exception as e:
+            self.logger.error(f"An error occurred during report generation: {e}", exc_info=True)
+
+    def _fetch_latest_kpi_snapshot(self) -> OpsKpiSnapshot | None:
+        """Fetches the most recent KPI snapshot from the database."""
+        self.logger.info("Fetching latest KPI snapshot...")
+        with self.db_connection.cursor() as cursor:
+            cursor.execute("""
+                SELECT ts, order_latency_p50_ms, order_latency_p95_ms,
+                       order_failure_rate, order_retry_rate,
+                       position_gross_exposure_usd, open_positions_count
+                FROM ops_kpi_snapshots
+                ORDER BY ts DESC
+                LIMIT 1;
+            """)
+            row = cursor.fetchone()
+            if row:
+                self.logger.info(f"Found KPI snapshot from: {row[0]}")
+                return OpsKpiSnapshot(
+                    ts=row[0],
+                    order_latency_p50_ms=row[1],
+                    order_latency_p95_ms=row[2],
+                    order_failure_rate=row[3],
+                    order_retry_rate=row[4],
+                    position_gross_exposure_usd=row[5],
+                    open_positions_count=row[6],
+                )
+        return None
+
+    def _format_report(self, snapshot: OpsKpiSnapshot) -> str:
+        """Formats the KPI data into a human-readable string."""
+        self.logger.info("Formatting KPI report...")
+        report_lines = [
+            f"📊 *Operational Report* ({snapshot.ts.strftime('%Y-%m-%d %H:%M Z')})",
+            "---------------------------",
+            f"🚀 **Execution**",
+            f"  - P50 Latency: {snapshot.order_latency_p50_ms} ms",
+            f"  - P95 Latency: {snapshot.order_latency_p95_ms} ms",
+            f"  - Failure Rate: {snapshot.order_failure_rate:.2%}",
+            "",
+            f"💼 **Portfolio**",
+            f"  - Open Positions: {snapshot.open_positions_count}",
+            f"  - Gross Exposure: ${snapshot.position_gross_exposure_usd:,.2f} USD",
+        ]
+        return "\n".join(report_lines)
+
+    def _enqueue_report(self, message: str):
+        """
+        Enqueues the report message in the notification outbox.
+        """
+        self.logger.info(f"Enqueuing report for chat_id: {DEFAULT_REPORT_CHAT_ID}")
+        with self.db_connection.cursor() as cursor:
+            # Use the enqueue_notification function in the DB
+            cursor.execute(
+                "SELECT enqueue_notification(%s, %s, %s, %s, %s);",
+                (
+                    DEFAULT_REPORT_CHAT_ID,
+                    'INFO', # severity
+                    'Daily KPI Report', # title
+                    message,
+                    f"kpi-report-{datetime.utcnow().strftime('%Y-%m-%d')}" # dedupe_key
+                ),
+            )
+            self.db_connection.commit()
+            self.logger.info("Successfully enqueued report.")

--- a/app/kpi/__init__.py
+++ b/app/kpi/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the kpi directory a Python package.

--- a/app/kpi/services.py
+++ b/app/kpi/services.py
@@ -1,0 +1,47 @@
+"""
+Service layer for calculating and retrieving operational KPIs.
+"""
+import logging
+from datetime import datetime, timezone
+from typing import Dict, Any, Optional
+
+import psycopg
+
+from app.models import OpsKpiSnapshot
+
+logger = logging.getLogger(__name__)
+
+def calculate_all_kpis(db_connection: psycopg.Connection) -> OpsKpiSnapshot:
+    """
+    Calculates all operational KPIs and returns them as a snapshot model.
+
+    This is a placeholder implementation that returns dummy data. In a real
+    scenario, this function would query the database (e.g., `orders`, `positions`
+    tables) to compute the actual metrics.
+
+    Args:
+        db_connection: An active database connection.
+
+    Returns:
+        An OpsKpiSnapshot object populated with the latest KPIs.
+    """
+    logger.info("Calculating all operational KPIs (using placeholder data)...")
+
+    # Placeholder logic: In a real implementation, you would run SQL queries here.
+    # For example:
+    # - latency: SELECT (updated_at - created_at) FROM orders WHERE status = 'FILLED' ...
+    # - failure_rate: SELECT COUNT(*) FROM orders WHERE status = 'REJECTED' ...
+    # - open_positions: SELECT COUNT(*) FROM positions WHERE quantity != 0 ...
+
+    snapshot = OpsKpiSnapshot(
+        ts=datetime.now(timezone.utc),
+        order_latency_p50_ms=120,
+        order_latency_p95_ms=350,
+        order_failure_rate=0.02,
+        order_retry_rate=0.05,
+        position_gross_exposure_usd=50275.50,
+        open_positions_count=3,
+    )
+
+    logger.info(f"KPI calculation complete: {snapshot.model_dump_json()}")
+    return snapshot

--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,7 @@ Data models for the trading application, using Pydantic for validation.
 """
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 from pydantic import BaseModel, Field
 
 class TradeSide(str, Enum):
@@ -35,3 +36,18 @@ class MarketSnapshot(BaseModel):
     low: float = Field(..., description="The lowest price of the candle")
     close: float = Field(..., description="The closing price of the candle")
     volume: float = Field(..., description="The trading volume of the candle")
+
+
+class OpsKpiSnapshot(BaseModel):
+    """
+    Represents a snapshot of operational KPIs.
+
+    This model corresponds to the `ops_kpi_snapshots` table.
+    """
+    ts: datetime = Field(..., description="The timestamp of the KPI snapshot (UTC)")
+    order_latency_p50_ms: Optional[int] = Field(None, description="p50 order latency in milliseconds")
+    order_latency_p95_ms: Optional[int] = Field(None, description="p95 order latency in milliseconds")
+    order_failure_rate: Optional[float] = Field(None, description="Ratio of failed orders")
+    order_retry_rate: Optional[float] = Field(None, description="Ratio of retried orders")
+    position_gross_exposure_usd: Optional[float] = Field(None, description="Gross exposure of all positions in USD")
+    open_positions_count: Optional[int] = Field(None, description="Total number of open positions")

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -14,8 +14,11 @@ from app.config import settings
 # Import the REAL agents, not the skeletons
 from app.agents.execution import ExecutionAgent
 from app.agents.risk import RiskAgent
+# Import the REAL agents, not the skeletons
+from app.agents.kpi import KpiAgent
+from app.agents.report import ReportAgent
 # Skeletons can be used for agents not yet implemented
-from app.agents.skeletons import IngestionAgent, StrategyAgent, ReportAgent
+from app.agents.skeletons import IngestionAgent, StrategyAgent
 from app.agents.notification import NotifyWorker
 
 # Configure logging
@@ -47,8 +50,8 @@ def main():
     # Instantiate the real, functional agents
     execution_agent = ExecutionAgent(db_connection=db_connection)
     risk_agent = RiskAgent(db_connection=db_connection, execution_agent=execution_agent)
-
-    report_agent = ReportAgent()
+    kpi_agent = KpiAgent(db_connection=db_connection)
+    report_agent = ReportAgent(db_connection=db_connection)
 
     # Instantiate the notification worker
     if settings.telegram_bot_token:
@@ -67,7 +70,10 @@ def main():
     scheduler.add_job(strategy_agent.run, 'interval', seconds=60, id='strategy_agent')
     # scheduler.add_job(execution_agent.run, 'interval', seconds=20, id='execution_agent')
     scheduler.add_job(risk_agent.run, 'interval', seconds=30, id='risk_agent')
-    scheduler.add_job(report_agent.run, 'interval', seconds=120, id='report_agent')
+
+    # Schedule the new KPI and Report agents
+    scheduler.add_job(kpi_agent.run, 'interval', minutes=5, id='kpi_agent')
+    scheduler.add_job(report_agent.run, 'interval', hours=1, id='report_agent')
 
     try:
         logger.info("Scheduler started. Press Ctrl+C to exit.")

--- a/db/schema_core.sql
+++ b/db/schema_core.sql
@@ -197,3 +197,15 @@ BEGIN
     RETURN v_id;
   END IF;
 END; $$ LANGUAGE plpgsql;
+
+
+-- Section 5.4: KPI Snapshots (from Plus optional module)
+CREATE TABLE IF NOT EXISTS ops_kpi_snapshots (
+  ts TIMESTAMPTZ PRIMARY KEY DEFAULT NOW(),
+  order_latency_p50_ms INT,
+  order_latency_p95_ms INT,
+  order_failure_rate NUMERIC,
+  order_retry_rate NUMERIC,
+  position_gross_exposure_usd NUMERIC,
+  open_positions_count INT
+);


### PR DESCRIPTION
This commit introduces the foundational structure for the M8 KPI & Report module as outlined in the design documents.

It includes:
- The database schema for the `ops_kpi_snapshots` table.
- A Pydantic model for KPI data (`OpsKpiSnapshot`).
- A new `KpiAgent` to periodically calculate and store KPIs.
- A new `ReportAgent` to fetch the latest KPIs and send a summary report to Telegram.
- Integration of the new agents into the main application scheduler.

Note: The core KPI calculation logic in `app/kpi/services.py` is currently implemented with placeholder data. The framework is in place for the real calculation logic to be added in a future step.